### PR TITLE
Fix so that bad JSON doesn't bring down the entire process

### DIFF
--- a/etl/tmdb.py
+++ b/etl/tmdb.py
@@ -65,6 +65,8 @@ def extract(movieIds=[]):
             movieDict[tmdbId] = movie
         except ConnectionError as e:
             print e
+        except ValueError:
+            print('Bad JSON found.')
     return movieDict
 
 


### PR DESCRIPTION
tmdb.py is a long running process; there is nothing more annoying than the service returning some unparsable content which would normally kill the process meaning you'd have to start again.